### PR TITLE
add GitHub Actions workflow for IPFS deployment and configure Vite ba…

### DIFF
--- a/.github/workflows/deploy-ipfs.yaml
+++ b/.github/workflows/deploy-ipfs.yaml
@@ -1,0 +1,34 @@
+name: Deploy to IPFS
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Install and Build
+        run: |
+          yarn install
+          yarn build
+        env:
+          VITE_WEB_API_URL: ${{ vars.VITE_WEB_API_URL }} 
+
+      - name: Upload to Pinata
+        uses: aquiladev/ipfs-action@v0.3.1
+        with:
+          path: ./dist
+          service: pinata
+          pinataKey: ${{ secrets.PINATA_API_KEY }}
+          pinataSecret: ${{ secrets.PINATA_SECRET_API_KEY }}
+          pinName: cfp-funding-tool-ui

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: './',
 })


### PR DESCRIPTION
ticket: https://github.com/gnosis/gnosis_vpn-infrastructure/issues/98

the change in the vite config file was an AI recommendation, I guess that might be correct:

```
Vite apps default to absolute paths (e.g., /assets/script.js). On IPFS, your app will be served from a path like https://ipfs.io/ipfs/QmHash.../. Absolute paths will break this.

Action: vite.config.ts to set base: './' to ensure assets are loaded relatively.
```